### PR TITLE
Upgrade to Arcade V4 publishing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
    <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
+      <PublishingVersion>4</PublishingVersion>
       <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages> <!-- we don't need symbol packages for wasi-sdk -->
    </PropertyGroup>
 

--- a/eng/azure-pipelines-public.yml
+++ b/eng/azure-pipelines-public.yml
@@ -27,12 +27,13 @@ stages:
     parameters:
       enablePublishBuildArtifacts: true
       enablePublishBuildAssets: true
-      enablePublishUsingPipelines: true
+      publishingVersion: 4
       enableMicrobuild: true
       jobs:
 
       ############ LINUX BUILD ############
       - job: Build_Linux
+        enablePublishing: true
         displayName: Linux
         timeoutInMinutes: 480
         strategy:
@@ -73,6 +74,7 @@ stages:
 
       ############ MACOS BUILD ############
       - job: Build_macOS
+        enablePublishing: true
         displayName: macOS
         timeoutInMinutes: 480
         strategy:
@@ -98,6 +100,7 @@ stages:
 
       ############ WINDOWS BUILD ############
       - job: Build_Windows
+        enablePublishing: true
         displayName: Windows
         timeoutInMinutes: 480
         strategy:
@@ -151,6 +154,7 @@ stages:
             artifactType: container
 
       - job: Build_Workloads
+        enablePublishing: true
         displayName: Workloads
         dependsOn:
           - Build_Windows

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -47,12 +47,13 @@ extends:
         parameters:
           enablePublishBuildArtifacts: true
           enablePublishBuildAssets: true
-          enablePublishUsingPipelines: true
+          publishingVersion: 4
           enableMicrobuild: true
           jobs:
 
           ############ LINUX x64 BUILD ############
           - job: Build_Linux_x64
+            enablePublishing: true
             displayName: Linux_x64
             timeoutInMinutes: 480
             pool:
@@ -76,6 +77,7 @@ extends:
 
           ############ LINUX arm64 BUILD ############
           - job: Build_Linux_arm64
+            enablePublishing: true
             displayName: Linux_arm64
             timeoutInMinutes: 480
             pool:
@@ -99,6 +101,7 @@ extends:
 
           ############ LINUX MUSL x64 BUILD ############
           - job: Build_Linux_musl_x64
+            enablePublishing: true
             displayName: Linux_musl_x64
             timeoutInMinutes: 480
             pool:
@@ -122,6 +125,7 @@ extends:
 
           ############ LINUX MUSL arm64 BUILD ############
           - job: Build_Linux_musl_arm64
+            enablePublishing: true
             displayName: Linux_musl_arm64
             timeoutInMinutes: 480
             pool:
@@ -145,6 +149,7 @@ extends:
 
           ############ MACOS x64 BUILD ############
           - job: Build_macOS_x64
+            enablePublishing: true
             displayName: macOS_x64
             timeoutInMinutes: 480
             pool:
@@ -167,6 +172,7 @@ extends:
 
           ############ MACOS arm64 BUILD ############
           - job: Build_macOS_arm64
+            enablePublishing: true
             displayName: macOS_arm64
             timeoutInMinutes: 480
             pool:
@@ -189,6 +195,7 @@ extends:
 
           ############ WINDOWS x64 BUILD ############
           - job: Build_Windows_x64
+            enablePublishing: true
             displayName: Windows_x64
             timeoutInMinutes: 480
             pool:
@@ -234,6 +241,7 @@ extends:
 
           ############ WINDOWS arm64 BUILD ############
           - job: Build_Windows_arm64
+            enablePublishing: true
             displayName: Windows_arm64
             timeoutInMinutes: 480
             pool:
@@ -279,6 +287,7 @@ extends:
 
           ############ Workloads BUILD ############
           - job: Build_Workloads
+            enablePublishing: true
             displayName: Workloads
             dependsOn:
               - Build_Windows_x64
@@ -349,6 +358,7 @@ extends:
     ############ POST BUILD ARCADE LOGIC ############
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:
+        publishingInfraVersion: 4
         enableSourceLinkValidation: false
         enableSigningValidation: false
         enableSymbolValidation: false

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -24,6 +24,5 @@ variables:
     - group: DotNet-HelixApi-Access
     - name: _InternalBuildArgs
       value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-        /p:DotNetPublishUsingPipelines=true
         /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)


### PR DESCRIPTION
## Summary
- switch `eng/Publishing.props` to `PublishingVersion` 4
- replace the legacy `enablePublishUsingPipelines` settings with V4 `publishingVersion`/`enablePublishing`
- update the official post-build stage to `publishingInfraVersion: 4`
- remove the stale `DotNetPublishUsingPipelines` build argument

## Validation
- parsed the updated Azure Pipelines YAML with PyYAML

Related to dotnet/arcade#16697.